### PR TITLE
adding CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License. 
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+*       @DataDog/dpn


### PR DESCRIPTION
#### Contribution Type

Repo maintenance

#### Description

Adds codeowners file

#### Value Add / Motivation

Adds default code reviewer

#### Sources

https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners

#### Testing Strategy

Will try adding a bogus PR after to see if the default is available. 
