### PR TITLE
adding an ecommerce sample web app

### DIFF
--- a/sandbox-apps/.setup.post.sh
+++ b/sandbox-apps/.setup.post.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+# called by the sandbox app's ./setup.sh script
+
+curl -X POST "https://browser-http-intake.logs.datadoghq.com/v1/input/${DPN_STRING}" \
+-H "Content-Type: application/json" \
+-d @- << EOF
+{
+	"message": "completed provisioning a sandbox app", 
+	"status": "info",
+	"sandbox-app": "voting-app",
+	"tag_defaults": "${TAG_DEFAULTS}",
+	"hostname_base": "${HOSTNAME_BASE}",
+	"step": "end",
+	"type": "${TYPE:-"None"}"
+}
+EOF
+
+echo "Operation complete!"

--- a/sandbox-apps/.setup.pre.sh
+++ b/sandbox-apps/.setup.pre.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+# called by the sandbox app's ./setup.sh script
+
+echo "Provisioning!"
+
+echo "apt-get updating"
+sudo apt-get update
+echo "installing curl, git..."
+sudo apt-get -y install curl git jq
+
+DPN_STRING="puba793760ef4e28fab630a7f13eda9e213"
+curl -X POST https://browser-http-intake.logs.datadoghq.com/v1/input/${DPN_STRING} \
+-H "Content-Type: application/json" \
+-d @- << EOF
+{
+	"message": "started provisioning a sandbox app", 
+	"status": "info",
+	"sandbox-app": "voting-app",
+	"tag_defaults": "${TAG_DEFAULTS}",
+	"hostname_base": "${HOSTNAME_BASE}",
+	"step": "start",
+	"type": "${TYPE:-"None"}"
+}
+EOF
+
+echo "installing docker..."
+sudo curl -sSL https://get.docker.com/ | sh
+echo "installing docker-compose"
+sudo curl -L "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+sudo docker-compose --version

--- a/sandbox-apps/_terraform/main.tf
+++ b/sandbox-apps/_terraform/main.tf
@@ -54,6 +54,20 @@ resource "aws_instance" "dpn-sandbox" {
     destination = "~/setup.sh"
   }
 
+  # testing
+  provisioner "file" {
+    source      = "${path.cwd}/.require.vars.sh"
+    destination = "~/.require.vars.sh"
+  }
+  provisioner "file" {
+    source      = "${path.cwd}/../.setup.pre.sh"
+    destination = "~/.setup.pre.sh"
+  }
+  provisioner "file" {
+    source      = "${path.cwd}/../.setup.post.sh"
+    destination = "~/.setup.post.sh"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "mkdir ~/data",

--- a/sandbox-apps/ecommerce-webapp/.require.vars.sh
+++ b/sandbox-apps/ecommerce-webapp/.require.vars.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+# called by the sandbox app's ./setup.sh script
+
+# quit if any of the required vars are not set
+[ -z "$DD_API_KEY" ] && echo "make sure to set DD_API_KEY in your setup.env file. exiting." && exit 1
+[ -z "$DD_APP_KEY" ] && echo "make sure to set DD_APP_KEY in your setup.env file. exiting." && exit 1
+[ -z "$PG_USER" ] && echo "make sure to set PG_USER in your setup.env file. exiting." && exit 1
+[ -z "$PG_PASS" ] && echo "make sure to set PG_PASS in your setup.env file. exiting." && exit 1
+[ -z "$HOSTNAME_BASE" ] && echo "make sure to set HOSTNAME_BASE in your setup.env file. exiting." && exit 1
+[ -z "$TAG_DEFAULTS" ] && echo "make sure to set TAG_DEFAULTS in your setup.env file. exiting." && exit 1

--- a/sandbox-apps/ecommerce-webapp/README.md
+++ b/sandbox-apps/ecommerce-webapp/README.md
@@ -1,0 +1,114 @@
+
+> Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+> This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+# Partners Demo Sample Voting App Installation Guide
+
+## Prerequisits:
+
+### Deploying Locally
+
+(Installation time expectation: 10 minutes)
+
+1. Clone or download this repo. (Git installation page (download [here](https://git-scm.com/downloads))
+2. Vagrant (download [here](https://www.vagrantup.com/downloads.html))
+3. VirtualBox (download [here](https://www.virtualbox.org/wiki/Downloads))
+
+### Deploying in AWS
+
+(Installation time expectation: 10-30 minutes, depending on your AWS account settings)
+
+1. Git (download [here](https://git-scm.com/downloads))
+2. Terraform (installation and configuration guide [here](https://github.com/DataDog/dpn/tree/master/sandbox-apps/_terraform))
+
+## Setup:
+
+(Time expectation: 10 minutes)
+
+1. Clone or download this repo. (Git installation page (download [here](https://git-scm.com/downloads))
+2. In a terminal/shell, move to the directory that holds the environment configurations. (`cd dpn/sandbox-apps/voting-app` or in powershell `cd .\dpn\sandbox-apps\voting-app`)
+3. Configure your `setup.env`, replacing all "REPLACE_ME" strings with your own values.
+4. To deploy locally: Run `vagrant up` (and then enter the "y" confirmation if prompted). To deploy in AWS: Run the terraform `apply` command (and then enter the "yes" confirmation when prompted)
+
+And then it should all work out magically from there. It may take about 5-10 minutes for the whole thing to get running, so maybe go grab some coffee and come back. And if you see a bunch of warning- / error-looking messages in your terminal, don't panic, some warnings and errors are actually expected and totally benign. 
+
+## Verification
+
+Once you have control of the terminal again, you know the setup has finished. The last messages you see before that should look like `Operation complete!` or `Creating * ... done.` At this point your app should be running and integrated nicely with your Datadog account. 
+
+In order to verify that you have all the expected data coming into your Datadog account, visit your local app at http://localhost:8000/ in your browser and select a few buttons. Then go to http://localhost:8080/ and do the same thing. If you deployed in AWS, your terminal will tell you the server IP addresses, so you can instead go to http://that_ip:8000/ and http://that_ip:8080/ instead.
+
+At this point, you should then start to data start to populate in your Datadog account in the following pages:
+
+(Verification photos and links forthecoming)
+<details>
+  <summary><a href="https://app.datadoghq.com/infrastructure" target="_blank">Infrastructure List</a></summary>
+  
+  ![Infrastructure List](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/infrastructure_list.jpg)
+</details>
+
+<details>
+  <summary><a href="https://app.datadoghq.com/dashboard/lists/preset/2" target="_blank">Host Dashboard</a></summary>
+  
+  ![Host Dashboard](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/host_dashboard.jpg)
+</details>
+
+<details>
+  <summary><a href="https://app.datadoghq.com/infrastructure/map?node_type=container" target="_blank">Container Map</a></summary>
+  
+  ![Container Map](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/container_map.jpg)
+</details>
+
+<details>
+  <summary><a href="https://app.datadoghq.com/containers" target="_blank">Containers List</a></summary>
+  
+  ![Container List](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/container_list.jpg)
+</details>
+
+<details>
+  <summary><a href="https://app.datadoghq.com/process" target="_blank">Processes List</a></summary>
+  
+  ![Process List](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/process_list.jpg)
+</details>
+
+<details>
+  <summary><a href="https://app.datadoghq.com/apm/map?env=dpn-sandbox" target="_blank">Service Map</a></summary>
+  
+  (make sure to scope to the relevant "env")
+
+  ![Service Map](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/service_map.jpg)
+</details>
+
+<details>
+  <summary><a href="https://app.datadoghq.com/apm/traces?env=dpn-sandbox" target="_blank">Trace Search</a></summary>
+  
+  (make sure to scope to the relevant "env")
+
+  ![Trace Search](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/trace_search.jpg)
+</details>
+
+<details>
+  <summary><a href="https://app.datadoghq.com/logs" target="_blank">Log Explorer</a></summary>
+
+  (you may have to click through the "getting started" flow before you see the logs)
+  
+  ![Log Explorer](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/log_explorer.jpg)
+</details>
+
+<details>
+  <summary><a href="https://app.datadoghq.com/screen/integration/256/jvm-metrics" target="_blank">JVM Integration Dashboard</a></summary>
+
+  ![JVM Dashboard](https://github.com/DataDog/dpn/blob/master/sandbox-apps/voting-app/static/images/jvm_dashboard.jpg)
+</details>
+
+## Shutting down
+
+You can pause your virtual machine that runs your app with `vagrant halt`, or you can destroy it completely with `vagrant destroy`. Whenever you want to run it again, you can just `vagrant up` again after that.
+
+For AWS deployments, you can tear down your application with the terraform `destroy` command, and rebuild again with the `apply` command. 
+
+## Troubleshooting
+
+If you want to access your vm to troubleshoot or modify anything, for local deployments you can do so with `vagrant ssh`. Once you're in the VM, you can run `sudo docker ps` to see what containers are running.
+
+For deployments in AWS, you can ssh to your instance with `ssh -i /path/to/<my_key_file>.pem ubuntu@<my_ip>` and from there you can run `sudo docker ps` to see what containers are running.

--- a/sandbox-apps/ecommerce-webapp/Vagrantfile
+++ b/sandbox-apps/ecommerce-webapp/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "bento/ubuntu-16.04"
+
+  config.vm.network :forwarded_port, guest: 8000, host: 8000, auto_correct: true
+  config.vm.network :forwarded_port, guest: 8080, host: 8080, auto_correct: true
+  config.vm.synced_folder "./data", "/data", create: true
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name = "Ecommerce Webapp"
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+  end
+
+  config.vm.provision "shell", inline: "mkdir ~/data"
+  config.vm.provision :file, source: './data', destination: '~/data'
+  config.vm.provision :file, source: './setup.env', destination: '~/setup.env'
+  config.vm.provision :file, source: './.require.vars.sh', destination: '~/.require.vars.sh'
+  config.vm.provision :file, source: '../.setup.pre.sh', destination: '~/.setup.pre.sh'
+  config.vm.provision :file, source: '../.setup.post.sh', destination: '~/.setup.post.sh'
+  config.vm.provision "shell", path: "./setup.sh", privileged: false
+
+end

--- a/sandbox-apps/ecommerce-webapp/data/.i.exist
+++ b/sandbox-apps/ecommerce-webapp/data/.i.exist
@@ -1,0 +1,1 @@
+hello, friend!

--- a/sandbox-apps/ecommerce-webapp/data/docker-compose.yml
+++ b/sandbox-apps/ecommerce-webapp/data/docker-compose.yml
@@ -1,0 +1,185 @@
+version: '3'
+services:
+  agent:
+    image: "datadog/agent:7.21.1"
+    environment:
+      - DD_API_KEY
+      - DD_APM_ENABLED=true
+      - DD_LOGS_ENABLED=true
+      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
+      - DD_PROCESS_AGENT_ENABLED=true
+      - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.team":"team"}
+      - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.stage":"stage"}
+      - DD_TAGS=__TAGS__
+      - DD_HOSTNAME=__HOSTNAME_BASE__
+    ports:
+      - "8126:8126"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "agent", "service": "agent"}]'
+  discounts:
+    environment:
+      - FLASK_APP=discounts.py
+      - FLASK_DEBUG=1
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+      - DD_SERVICE=discounts-service
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_TRACE_ANALYTICS_ENABLED=true
+      - DD_PROFILING_ENABLED=true
+    build: ../../discounts-service/
+    command: ddtrace-run flask run --port=5001 --host=0.0.0.0
+    volumes:
+      - "../../discounts-service:/app"
+    ports:
+      - "5001:5001"
+    depends_on:
+      - agent
+      - db
+    labels:
+      # com.datadoghq.ad.logs: '[{"source": "python", "service": "discounts-service"}]'
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "discounts-service", "log_processing_rules": [{"type": "multi_line", "name": "new_log_start_with_date", "pattern": "\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
+      my.custom.label.team: "discount"
+      my.custom.label.stage: "working"
+  frontend:
+    environment:
+      - DD_AGENT_HOST=agent
+      - DD_SERVICE=store-frontend
+      - DD_LOGS_INJECTION=true
+      - DD_TRACE_ANALYTICS_ENABLED=true
+      - DB_USERNAME=__PG_USER__
+      - DB_PASSWORD=__PG_PASS__
+      - DD_CLIENT_TOKEN
+      - DD_APPLICATION_ID
+    # image: "ddtraining/ecommerce-frontend:latest"
+    build: ../../store-frontend-instrumented-fixed/
+    command: sh docker-entrypoint.sh
+    ports:
+      - "8000:3000"
+    depends_on:
+      - agent
+      - db
+      - discounts
+      - advertisements
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "ruby", "service": "store-frontend"}]'
+      my.custom.label.team: "frontend"
+      my.custom.label.stage: "working"
+  advertisements:
+    environment:
+      - FLASK_APP=ads.py
+      - FLASK_DEBUG=1
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+      - DD_SERVICE=advertisements-service
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_TRACE_ANALYTICS_ENABLED=true
+      - DD_PROFILING_ENABLED=true
+    image: "ddtraining/advertisements-service:latest"
+    command: ddtrace-run flask run --port=5002 --host=0.0.0.0
+    ports:
+      - "5002:5002"
+    depends_on:
+      - agent
+      - db
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "ads-service"}]'
+      my.custom.label.team: "advertisements"
+      my.custom.label.stage: "working"
+  db:
+    image: postgres:11-alpine
+    restart: always
+    environment:
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'
+      my.custom.label.stage: "working"
+
+  discounts-broken:
+    environment:
+      - FLASK_APP=discounts.py
+      - FLASK_DEBUG=1
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+      - DD_SERVICE=discounts-service
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_TRACE_ANALYTICS_ENABLED=true
+      - DD_PROFILING_ENABLED=true
+      - DD_VERSION=1.0
+    image: "ddtraining/discounts-service:latest"
+    command: ddtrace-run flask run --port=5011 --host=0.0.0.0
+    ports:
+      - "5011:5011"
+    volumes:
+      - "../../discounts-service:/app"
+    depends_on:
+      - agent
+      - db-broken
+    labels:
+      # com.datadoghq.ad.logs: '[{"source": "python", "service": "discounts-service"}]'
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "discounts-service", "log_processing_rules": [{"type": "multi_line", "name": "new_log_start_with_date", "pattern": "\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])"}]}]'
+      my.custom.label.stage: "broken"
+  frontend-broken:
+    environment:
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_TRACE_ANALYTICS_ENABLED=true
+      - DD_SERVICE=store-frontend
+      - DD_VERSION=1.0
+      - DB_USERNAME=__PG_USER__
+      - DB_PASSWORD=__PG_PASS__
+      - DD_CLIENT_TOKEN
+      - DD_APPLICATION_ID
+    image: "ddtraining/ecommerce-frontend:latest"
+    build: ../../store-frontend-broken-instrumented/
+    command: sh docker-entrypoint.sh
+    ports:
+      - "8080:3000"
+    depends_on:
+      - agent
+      - db-broken
+      - discounts-broken
+      - advertisements-broken
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "ruby", "service": "store-frontend"}]'
+      my.custom.label.stage: "broken"
+  advertisements-broken:
+    environment:
+      - FLASK_APP=ads.py
+      - FLASK_DEBUG=1
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+      - DD_SERVICE=advertisements-service
+      - DD_AGENT_HOST=agent
+      - DD_LOGS_INJECTION=true
+      - DD_TRACE_ANALYTICS_ENABLED=true
+      - DD_PROFILING_ENABLED=true
+      - DD_VERSION=1.0
+    image: "ddtraining/advertisements-service:latest"
+    command: ddtrace-run flask run --port=5012 --host=0.0.0.0
+    ports:
+      - "5012:5012"
+    volumes:
+      - "../../ads-service:/app"
+    depends_on:
+      - agent
+      - db-broken
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "ads-service"}]'
+      my.custom.label.stage: "broken"
+  db-broken:
+    image: postgres:11-alpine
+    restart: always
+    environment:
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'
+      my.custom.label.stage: "broken"

--- a/sandbox-apps/ecommerce-webapp/ecommerce-webapp.tf
+++ b/sandbox-apps/ecommerce-webapp/ecommerce-webapp.tf
@@ -1,0 +1,13 @@
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+module "sandbox-apps" {
+  resource_name = "ecommerce-webapp"
+  source = "../_terraform/"
+  resource_size = "t2.medium" # only change for unusually large/small projects. bigger == $$$
+}
+
+output "entry" {
+  value = "${module.sandbox-apps.user}@${module.sandbox-apps.dns}"
+}

--- a/sandbox-apps/ecommerce-webapp/setup.env.example
+++ b/sandbox-apps/ecommerce-webapp/setup.env.example
@@ -1,0 +1,30 @@
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+
+# Replace all REPLACE_ME strings with your own values
+
+
+#################
+#               #
+# Required vars #
+#               #
+#################
+
+# Datadog keys
+DD_API_KEY=REPLACE_ME
+DD_APP_KEY=REPLACE_ME
+
+# postgres username and password
+PG_USER=REPLACE_ME
+PG_PASS=REPLACE_ME
+
+HOSTNAME_BASE=REPLACE_ME
+# HOSTNAME_BASE will become part of the hostname for your sandbox environment.
+# it will help clarify what host is which in your Datadog account.
+# example: HOSTNAME_BASE=jane.doe.laptop
+
+TAG_DEFAULTS="REPLACE_ME REPLACE_ME"
+# TAG_DEFAULTS defines what host tags are applied to the sandbox environment by default
+# example: TAG_DEFAULTS="creator:jane.doe role:sandbox laptop:oct-2019"

--- a/sandbox-apps/ecommerce-webapp/setup.sh
+++ b/sandbox-apps/ecommerce-webapp/setup.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+# translate setup.env to unix-friendly just in case it came from dos
+sudo sed -e "s/\r//g" setup.env > setup.env.new
+sudo mv setup.env.new setup.env
+
+# get env variables
+. setup.env
+
+# quit if any of the required vars are not set
+. .require.vars.sh
+
+# run preprovisioning
+. .setup.pre.sh
+
+# Clone the app repo
+echo "cloning app repo"
+
+# create RUM project
+response=$(curl -X POST "https://api.datadoghq.com/api/v1/rum/projects" \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${DD_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+-d @- << EOF
+{
+  "name": "storedog-${HOSTNAME_BASE}"
+}
+EOF
+)
+RUM_ID=$(echo $response | jq -r '.id')
+RUM_HASH=$(echo $response | jq -r '.hash')
+
+# setup
+sudo git clone https://github.com/DataDog/ecommerce-workshop.git
+sudo cp ./data/docker-compose.yml ./ecommerce-workshop/deploy/docker-compose/
+
+cd ecommerce-workshop/deploy/docker-compose
+
+sudo sed -i.bak "s|__TAGS__|${TAG_DEFAULTS}|g" ./docker-compose.yml
+sudo sed -i.bak "s|__HOSTNAME_BASE__|${HOSTNAME_BASE}|g" ./docker-compose.yml
+sudo sed -i.bak "s|__PG_USER__|${PG_USER}|g" ./docker-compose.yml
+sudo sed -i.bak "s|__PG_PASS__|${PG_PASS}|g" ./docker-compose.yml
+
+# deploy 
+sudo POSTGRES_USER=${PG_USER:-e.alderson} POSTGRES_PASSWORD=${PG_PASS:-the9cake4is8a3lie} DD_API_KEY=${DD_API_KEY} DD_CLIENT_TOKEN=${RUM_HASH} DD_APPLICATION_ID=${RUM_ID} docker-compose -f docker-compose.yml up -d
+
+# make a couple requests
+curl localhost:8000
+curl localhost:8080
+
+# run postprovisioning
+cd ../../../
+. ./.setup.post.sh
+
+echo """
+Completed provisioning. 
+Check your Datadog account for the storedog-${HOSTNAME_BASE} application. 
+Make requests on ports 8000 for the healthy version fo the app, 
+and on port 8080 for the unhealthy version of the app.
+"""

--- a/sandbox-apps/sample-app-todo/.require.vars.sh
+++ b/sandbox-apps/sample-app-todo/.require.vars.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+#
+# this file is a placeholder to make sure the terraform template works on older sample apps

--- a/sandbox-apps/voting-app/.require.vars.sh
+++ b/sandbox-apps/voting-app/.require.vars.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+#
+# this file is a placeholder to make sure the terraform template works on older sample apps


### PR DESCRIPTION
#### Contribution Type

Sample App

#### Description

Adds an ecommerce web app that you can spin up twice at once -- one version with errors, the other without. 

#### Value Add / Motivation

The logs, traces, etc. that the app generates are more realistic than those provided by any of the sample apps up to this point. Will make for some great demos. 

#### Sources

https://github.com/DataDog/ecommerce-workshop#ecommerce-observability-in-practice

#### Testing Strategy

I built and tested it locally and in EC2 instances with success. 

#### TODO

Still have to add screenshots of the verification section in the readme
