### PR TITLE
updated xenial to fossa

### DIFF
--- a/sandbox-apps/ecommerce-webapp/Vagrantfile
+++ b/sandbox-apps/ecommerce-webapp/Vagrantfile
@@ -5,7 +5,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-20.04"
 
   config.vm.network :forwarded_port, guest: 8000, host: 8000, auto_correct: true
   config.vm.network :forwarded_port, guest: 8080, host: 8080, auto_correct: true


### PR DESCRIPTION
#### Contribution Type

Bugfix

#### Description

The vagrant file was using the xenial base image. I updated the version number to use fossa.

#### Value Add / Motivation

Ubuntu Xenial is end of life, causing a possible security risk to people running the sandbox app.

#### Sources

n/a

#### Testing Strategy

Tested in local lab.
