### PR TITLE
have voting-app and todo-list use setup.pre-post.sh

### DIFF
--- a/sandbox-apps/sample-app-todo/.require.vars.sh
+++ b/sandbox-apps/sample-app-todo/.require.vars.sh
@@ -3,4 +3,10 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 #
-# this file is a placeholder to make sure the terraform template works on older sample apps
+# called by the sandbox app's ./setup.sh script
+
+# quit if any of the required vars are not set
+[ -z "$DD_API_KEY" ] && echo "make sure to set DD_API_KEY in your setup.env file. exiting." && exit 1
+[ -z "$DD_APP_KEY" ] && echo "make sure to set DD_APP_KEY in your setup.env file. exiting." && exit 1
+[ -z "$HOSTNAME_BASE" ] && echo "make sure to set HOSTNAME_BASE in your setup.env file. exiting." && exit 1
+[ -z "$TAG_DEFAULTS" ] && echo "make sure to set TAG_DEFAULTS in your setup.env file. exiting." && exit 1

--- a/sandbox-apps/sample-app-todo/Vagrantfile
+++ b/sandbox-apps/sample-app-todo/Vagrantfile
@@ -22,6 +22,9 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: "mkdir ~/data"
   config.vm.provision :file, source: './data', destination: '~/data'
   config.vm.provision :file, source: './setup.env', destination: '~/setup.env'
+  config.vm.provision :file, source: './.require.vars.sh', destination: '~/.require.vars.sh'
+  config.vm.provision :file, source: '../.setup.pre.sh', destination: '~/.setup.pre.sh'
+  config.vm.provision :file, source: '../.setup.post.sh', destination: '~/.setup.post.sh'
   config.vm.provision "shell", path: "./setup.sh", privileged: false
   
 end

--- a/sandbox-apps/sample-app-todo/setup.env.example
+++ b/sandbox-apps/sample-app-todo/setup.env.example
@@ -1,0 +1,26 @@
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+
+# Replace all REPLACE_ME strings with your own values
+
+
+#################
+#               #
+# Required vars #
+#               #
+#################
+
+# Datadog keys
+DD_API_KEY=REPLACE_ME
+DD_APP_KEY=REPLACE_ME
+
+HOSTNAME_BASE=REPLACE_ME
+# HOSTNAME_BASE will become part of the hostname for your sandbox environment.
+# it will help clarify what host is which in your Datadog account.
+# example: HOSTNAME_BASE=jane.doe.laptop
+
+TAG_DEFAULTS="REPLACE_ME REPLACE_ME"
+# TAG_DEFAULTS defines what host tags are applied to the sandbox environment by default
+# example: TAG_DEFAULTS="creator:jane.doe role:sandbox laptop:oct-2019"

--- a/sandbox-apps/sample-app-todo/setup.sh
+++ b/sandbox-apps/sample-app-todo/setup.sh
@@ -11,31 +11,13 @@ sudo mv setup.env.new setup.env
 # get env variables
 . setup.env
 
+# quit if any of the required vars are not set
+. .require.vars.sh
+
+# run preprovisioning
+. .setup.pre.sh
 
 START_DIR=$(pwd)
-
-echo "Provisioning!"
-
-echo "apt-get updating"
-sudo apt-get update
-echo "install curl if not there..."
-sudo apt-get -y install curl
-echo "installing git if not there..."
-sudo apt-get -y install git
-
-DPN_STRING="puba793760ef4e28fab630a7f13eda9e213"
-curl -X POST https://browser-http-intake.logs.datadoghq.com/v1/input/${DPN_STRING} \
--H "Content-Type: application/json" \
--d @- << EOF
-{
-	"message": "started provisioning a sandbox app", 
-	"status": "info",
-	"sandbox-app": "sandbox-app-todo",
-	"tag_defaults": "${TAG_DEFAULTS}",
-	"hostname_base": "${HOSTNAME_BASE}",
-	"step": "start"
-}
-EOF
 
 echo "installing docker if not there..."
 sudo curl -sSL https://get.docker.com/ | sh
@@ -103,15 +85,6 @@ cd $START_DIR/dd-partner-app/nodejs-dummy
 sudo docker network create my-net
 sudo docker-compose up -d
 
-curl -X POST https://browser-http-intake.logs.datadoghq.com/v1/input/${DPN_STRING} \
--H "Content-Type: application/json" \
--d @- << EOF
-{
-	"message": "completed provisioning a sandbox app", 
-	"status": "info",
-	"sandbox-app": "sandbox-app-todo",
-	"tag_defaults": "${TAG_DEFAULTS}",
-	"hostname_base": "${HOSTNAME_BASE}",
-	"step": "end"
-}
-EOF
+# run postprovisioning
+cd ../../../
+. ./.setup.post.sh

--- a/sandbox-apps/voting-app/.require.vars.sh
+++ b/sandbox-apps/voting-app/.require.vars.sh
@@ -3,4 +3,13 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 #
-# this file is a placeholder to make sure the terraform template works on older sample apps
+# called by the sandbox app's ./setup.sh script
+
+# quit if any of the required vars are not set
+[ -z "$DD_API_KEY" ] && echo "make sure to set DD_API_KEY in your setup.env file. exiting." && exit 1
+[ -z "$DD_APP_KEY" ] && echo "make sure to set DD_APP_KEY in your setup.env file. exiting." && exit 1
+[ -z "$PG_USER" ] && echo "make sure to set PG_USER in your setup.env file. exiting." && exit 1
+[ -z "$PG_PASS" ] && echo "make sure to set PG_PASS in your setup.env file. exiting." && exit 1
+[ -z "$HOSTNAME_BASE" ] && echo "make sure to set HOSTNAME_BASE in your setup.env file. exiting." && exit 1
+[ -z "$TAG_DEFAULTS" ] && echo "make sure to set TAG_DEFAULTS in your setup.env file. exiting." && exit 1
+[ -z "$TYPE" ] && echo "make sure to set TYPE in your setup.env file. exiting." && exit 1

--- a/sandbox-apps/voting-app/Vagrantfile
+++ b/sandbox-apps/voting-app/Vagrantfile
@@ -19,6 +19,9 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: "mkdir ~/data"
   config.vm.provision :file, source: './data', destination: '~/data'
   config.vm.provision :file, source: './setup.env', destination: '~/setup.env'
+  config.vm.provision :file, source: './.require.vars.sh', destination: '~/.require.vars.sh'
+  config.vm.provision :file, source: '../.setup.pre.sh', destination: '~/.setup.pre.sh'
+  config.vm.provision :file, source: '../.setup.post.sh', destination: '~/.setup.post.sh'
   config.vm.provision "shell", path: "./setup.sh", privileged: false
 
 end


### PR DESCRIPTION
#### Contribution Type

sample app configs

#### Description

sets the older sample apps to use the setup.pre.sh and setup.post.sh

#### Value Add / Motivation

this is a new standard for all sample apps

#### Sources

#### Testing Strategy

plan to run this to confirm it all works as intended
