### PR TITLE
re-enable renovate with 2-day cooldown

### DIFF
--- a/sandbox-apps/aws-microservices-demo-multiarch-main/renovate.json
+++ b/sandbox-apps/aws-microservices-demo-multiarch-main/renovate.json
@@ -4,7 +4,9 @@
   ],
   "pip-compile": {
     "enabled": true,
-    "fileMatch": ["(^|/)requirements\\.in$"],
+    "fileMatch": [
+      "(^|/)requirements\\.in$"
+    ],
     "lockFileMaintenance": {
       "enabled": true
     }
@@ -12,39 +14,53 @@
   "constraints": {
     "python": "~=3.10.0"
   },
-  "prConcurrentLimit":8,
-  "stabilityDays":7,
-  "vulnerabilityAlerts":{
-     "labels":[
-       "type:security" 
-     ],
-     "stabilityDays":0
+  "prConcurrentLimit": 8,
+  "stabilityDays": 7,
+  "vulnerabilityAlerts": {
+    "labels": [
+      "type:security"
+    ],
+    "stabilityDays": 0
   },
   "postUpdateOptions": [
     "gomodTidy",
     "npmDedupe"
   ],
-  "labels": ["dependencies"],
-  "python":{
-    "addLabels": ["lang: python"]
+  "labels": [
+    "dependencies"
+  ],
+  "python": {
+    "addLabels": [
+      "lang: python"
+    ]
   },
-  "java":{
-    "addLabels": ["lang: java"]
+  "java": {
+    "addLabels": [
+      "lang: java"
+    ]
   },
-  "golang":{
-    "addLabels": ["lang: go"]
+  "golang": {
+    "addLabels": [
+      "lang: go"
+    ]
   },
-  "nuget":{
-    "addLabels": ["lang: dotnet"]
+  "nuget": {
+    "addLabels": [
+      "lang: dotnet"
+    ]
   },
-  "npm":{
-    "addLabels": ["lang: nodejs"]
+  "npm": {
+    "addLabels": [
+      "lang: nodejs"
+    ]
   },
   "docker": {
     "pinDigests": true
   },
   "kubernetes": {
-    "fileMatch": ["\\.yaml$"],
+    "fileMatch": [
+      "\\.yaml$"
+    ],
     "ignorePaths": [
       "release/**",
       "kustomize/base/**",
@@ -63,9 +79,14 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
       "automerge": true
     }
   ],
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "minimumReleaseAge": "2 days"
 }


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are adding a 2-day cooldown (`minimumReleaseAge`) on dependencies to reduce the risk of zero-day vulnerabilities.

This PR re-enables your Renovate configuration and introduces the cooldown setting. If you notice any other configurations in your repo that are missing the cooldown, please ensure it is added.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.